### PR TITLE
Fix SQL query to use wildcard search for book names

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,7 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE name LIKE %s", name
+            "SELECT * FROM books WHERE name LIKE '%" + name + "%'", name
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Enable wildcard matching in book name search by wrapping the query parameter with '%' in the SQL LIKE clause.